### PR TITLE
Stop abusing URI->path

### DIFF
--- a/lib/Authen/OATH/KeyURI.pm
+++ b/lib/Authen/OATH/KeyURI.pm
@@ -106,7 +106,8 @@ sub _generate_uri {
         ($self->issuer) ? 
             $self->issuer . q{:} . $self->accountname :
             $self->accountname;
-    $uri->path(q{//} . $self->type . q{/} . $label);
+    $uri->authority($self->type);
+    $uri->path($label);
 
     # 3. Parameters
     my $params = {


### PR DESCRIPTION
The "type" section of our output URI is a logical authority, not part of
the path. Trying to ram a double-slash into the start of the path of a
SCHEME:PATH URI produces a valid warning when warnings are on.
